### PR TITLE
Remove install of Python 2 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ This includes, but is not limited to:
 - [Homebrew](http://brew.sh/)
 - Up-to-date or cfgov-refresh-specific versions of several core developer tools:
   - Git (replacing Apple Git)
-  - pyenv and pyenv-virtualenvwrapper, with:
-    - Python 3 (as `python`)
-    - Python 2 (as `python2`)
+  - pyenv and pyenv-virtualenvwrapper, with Python 3
   - PostgreSQL
   - nvm with the latest LTS release of Node
   - Yarn with the following installed globally:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This includes, but is not limited to:
 - [Homebrew](http://brew.sh/)
 - Up-to-date or cfgov-refresh-specific versions of several core developer tools:
   - Git (replacing Apple Git)
-  - pyenv and pyenv-virtualenvwrapper, with Python 3
+  - pyenv and pyenv-virtualenvwrapper with Python 3.6.9
   - PostgreSQL
   - nvm with the latest LTS release of Node
   - Yarn with the following installed globally:

--- a/provision_tools.sh
+++ b/provision_tools.sh
@@ -20,7 +20,7 @@ echo "!¡!¡! (This will take a while. Stretch your legs.)"
 brew install git git-secrets pyenv pyenv-virtualenvwrapper
 
 
-# Set up Python stuff.
+# Setup Python environment.
 # Following the instructions at:
 # https://github.com/cfpb/development/blob/master/guides/installing-python.md
 echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! INITIALIZING PYENV ¡!¡!¡\033[0m"
@@ -34,17 +34,15 @@ if command -v pyenv 1>/dev/null 2>&1; then
   eval "$(pyenv init -)"
 fi
 
-## Install the versions of Python that we use.
-export PY2_VER="2.7.16"
+## Install the version of Python that we use.
 export PY3_VER="3.6.9"
-echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! INSTALLING PYTHON ${PY3_VER} AND ${PY2_VER} ¡!¡!¡\033[0m"
+echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! INSTALLING PYTHON ${PY3_VER} ¡!¡!¡\033[0m"
 pyenv install ${PY3_VER}
-pyenv install ${PY2_VER}
 
 ## Set the global Python versions.
-echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! SETTING GLOBAL PYTHON VERSIONS ¡!¡!¡\033[0m"
-echo "!¡!¡! (This will make python version ${PY3_VER}, and python2 will be ${PY2_VER}.)"
-pyenv global ${PY3_VER} ${PY2_VER}
+echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! SETTING GLOBAL PYTHON VERSION ¡!¡!¡\033[0m"
+echo "!¡!¡! (This will make python version ${PY3_VER}.)"
+pyenv global ${PY3_VER}
 
 # Install NVM (Node Version Manager).
 # https://github.com/nvm-sh/nvm

--- a/provision_tools.sh
+++ b/provision_tools.sh
@@ -20,7 +20,7 @@ echo "!¡!¡! (This will take a while. Stretch your legs.)"
 brew install git git-secrets pyenv pyenv-virtualenvwrapper
 
 
-# Setup Python environment.
+# Set up Python environment.
 # Following the instructions at:
 # https://github.com/cfpb/development/blob/master/guides/installing-python.md
 echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! INITIALIZING PYENV ¡!¡!¡\033[0m"
@@ -41,7 +41,6 @@ pyenv install ${PY3_VER}
 
 ## Set the global Python versions.
 echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! SETTING GLOBAL PYTHON VERSION ¡!¡!¡\033[0m"
-echo "!¡!¡! (This will make python version ${PY3_VER}.)"
 pyenv global ${PY3_VER}
 
 # Install NVM (Node Version Manager).


### PR DESCRIPTION
Only Python 3 will be supported going forward

## Changes

- Updated README.md to remove Python 2
- Removed PY2_VER variable and its use from provision_tools.sh

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
