### PR TITLE
Update version of nvm to v0.38.0

### DIFF
--- a/provision_tools.sh
+++ b/provision_tools.sh
@@ -50,7 +50,7 @@ brew install pipx
 # Install NVM (Node Version Manager).
 # https://github.com/nvm-sh/nvm
 echo -e "\033[44;97m!¡!¡! CFPB Mac Setup !¡!¡! INSTALLING NVM ¡!¡!¡\033[0m"
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 
 ## Export necessary environment variable for use in this script.
 export NVM_DIR="${HOME}/.nvm"


### PR DESCRIPTION
Update version of nvm

## Changes

- nvm v0.34.0 -> v0.38.0 in provision_tools.sh

## Testing

1. Run provision_tools.sh or
```
curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
